### PR TITLE
Exception syntax change for py3

### DIFF
--- a/src/x509_scitokens_issuer/x509_scitokens_issuer.py
+++ b/src/x509_scitokens_issuer/x509_scitokens_issuer.py
@@ -178,7 +178,7 @@ def launch_updater_thread():
     def updater_target(repeat=True):
         try:
             update_app()
-        except Exception, e:
+        except Exception as e:
             print("Failure occurred when trying to update the app config:", str(e))
             traceback.print_exc()
         if repeat:


### PR DESCRIPTION
This fix prevents the following error when building:

Bytecompiling .py files below /builddir/build/BUILDROOT/x509-scitokens-issuer-0.8.1-1.osg35.el8.x86_64/usr/lib/python3.6 using /usr/libexec/platform-python
*** Error compiling '/builddir/build/BUILDROOT/x509-scitokens-issuer-0.8.1-1.osg35.el8.x86_64/usr/lib/python3.6/site-packages/x509_scitokens_issuer/x509_scitokens_issuer.py'...
  File "/usr/lib/python3.6/x509_scitokens_issuer.py", line 181
    except Exception, e:
                    ^
SyntaxError: invalid syntax